### PR TITLE
Update deployments_controller.rb

### DIFF
--- a/app/controllers/deployments_controller.rb
+++ b/app/controllers/deployments_controller.rb
@@ -124,7 +124,7 @@ class DeploymentsController < ApplicationController
   end
 
   def ensure_deployment_possible
-    if current_stage.deployment_possible?
+    if ensure_user_access && current_stage.deployment_possible?
       true
     else
       respond_to do |format|


### PR DESCRIPTION
Fixed privilege escalation vulnerability.

A read-only user was able to start a new deploy or any other write action, by accessing the form from the deploy recap (with the log).